### PR TITLE
Fix failed to save sites order

### DIFF
--- a/functions/api/[[catchall]].js
+++ b/functions/api/[[catchall]].js
@@ -100,7 +100,7 @@ async function handleApiRequest(request, env) {
           ).all();
           return jsonResponse(results || []);
         }
-        if (request.method === 'POST' && !pathParts[3]) {
+        if (request.method === 'POST' && !pathParts[2]) {
           const { categoryId, name, url, icon, description, tags, group_id } = await request.json();
           if (!categoryId || !name || !url) return jsonResponse({ error: 'Missing fields' }, 400);
           

--- a/src/worker.js
+++ b/src/worker.js
@@ -91,7 +91,7 @@ async function handleApiRequest(request, env) {
           ).all();
           return jsonResponse(results || []);
         }
-        if (request.method === 'POST' && !pathParts[3]) {
+        if (request.method === 'POST' && !pathParts[2]) {
           const { categoryId, name, url, icon, description, tags, group_id } = await request.json();
           if (!categoryId || !name || !url) return jsonResponse({ error: 'Missing fields' }, 400);
           const { results } = await env.DB.prepare(


### PR DESCRIPTION
Fix API routing for site order saving to prevent "Missing fields" error.

`POST /api/sites/order` was incorrectly routed to the site creation endpoint, causing a "Missing fields" error due to missing `name` and `url` parameters. This PR corrects the path matching logic to properly distinguish between `/api/sites` (creation) and `/api/sites/order` (order update).

---
<a href="https://cursor.com/background-agent?bcId=bc-741d95bd-04e4-469b-928b-532078c988ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-741d95bd-04e4-469b-928b-532078c988ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

